### PR TITLE
CSSの追加

### DIFF
--- a/develop/index.css
+++ b/develop/index.css
@@ -78,12 +78,12 @@
 }
 
 /*土曜日*/
-.cal__week-sat {
+.cal__week--sat {
     color: #006fd0;
 }
 
 /*日曜日*/
-.cal__week-sun {
+.cal__week--sun {
     color: #cd0042;
 }
 

--- a/develop/index.css
+++ b/develop/index.css
@@ -1,0 +1,113 @@
+/*カレンダー*/
+.cal {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    font-weight: normal;
+    line-height: 1.8;
+    box-shadow: 1px 2px 6px 0px rgb(0 0 0 / 20%);
+    width: fit-content;
+    height: fit-content;
+    position: fixed;
+    inset: 0;
+    margin: auto;
+}
+
+/*ヘッダー*/
+.cal__header {
+    background-color: #14b0eb;
+    color: #ffffff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5em;
+}
+
+/*矢印マーク*/
+.cal__arrow {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 2em;
+    height: 2em;
+    cursor: pointer;
+}
+
+.cal__arrow::before {
+    content: "";
+    border: solid #ffffff;
+    border-width: 2px 2px 0 0;
+    width: 0.5em;
+    height: 0.5em;
+    display: block;
+}
+
+/*前月移動ナビ*/
+.cal__prev::before {
+    transform: rotate(-135deg);
+}
+
+/*翌月移動ナビ*/
+.cal__next::before {
+    transform: rotate(45deg);
+}
+
+/*年月表示部*/
+.cal__title {
+    color: #ffffff;
+    font-weight: bold;
+}
+
+/*日付の部分*/
+.cal--body table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+/*セルの基本スタイル*/
+.cal__body th,
+.cal__body td {
+    padding: 0.5em 1em;
+    text-align: center;
+    font-weight: normal;
+}
+
+/*曜日の基本スタイル*/
+.cal__week {
+    color: #cccccc;
+}
+
+/*土曜日*/
+.cal__week-sat {
+    color: #006fd0;
+}
+
+/*日曜日*/
+.cal__week-sun {
+    color: #cd0042;
+}
+
+/*日付の基本スタイル*/
+.cal__day {
+    color: #333333;
+}
+
+/*前月の日付*/
+.cal__day--prev {
+    color: #eeeeee;
+}
+
+/*翌月の日付*/
+.cal__day--next {
+    color: #eeeeee;
+}
+
+/*土曜日*/
+.cal__day--sat {
+    color: #006fd0;
+}
+
+/*日曜日*/
+.cal__day--sun {
+    color: #cd0042;
+}


### PR DESCRIPTION
### やったこと
- CSSを追加した。

### 学んだこと
-  `font-family` について、
1. 優先的に使ってほしいフォントを前に書く。
2. はじめに英語フォント、次に日本語フォントを指定する（アルファベットだけ英語フォントで表示されるように）。
3. Windows、Mac、iPhoneの3環境をカバーするように複数のフォントを書く。
4. 間に半角スペースの入るフォント名はクオテーション（'もしくは"）ではさむ。
-  `em` はHTMLの大きさを指定する単位で、デフォルトの値は `1em` = `16px` 。
-  `line-height` は行間ではなく、それぞれの行の高さを指定する。
-  `box-shadow: [offset-x] [offset-y] [blur-radius] [spread-radius] [color];` について、
1.  `offset-x` ：影の水平方向のオフセット（ずれ）を指定する。
2.  `offset-y` ：影の垂直方向のオフセット（ずれ）を指定する。
3.  `blur-radius` ：影のぼかし半径を指定する。
4.  `spread-radius` ：影の広がり半径を指定する。
5.  `color` ：影の色を指定する。
-  `fit-content` によって、要素の幅が中身のコンテンツが本来必要とする幅になる。
- 通常要素は縦に積まれていくが、この親要素に対して `display: flex;` を指定すると横並びになる。
-  `justify-content` プロパティの用途は具体的には要素を左寄せにしたり真ん中に寄せたりと要素の揃え位置を指定する。
-  `space-between` はアイテムの間にスペースを均等に割り付ける。
-  `justify-content` は横軸基準のアイテムの配置方法で、 `align-items` は縦軸基準のアイテムの配置方法。
-  `cursor` プロパティは,、特定の HTML 要素の上にマウスカーソルが乗ったときにそのカーソルの見た目（形）を指定する。
-  `: : before` は、CSSの疑似要素（Pseudo-element） の一つで、指定した HTML 要素の「中身（コンテンツ）の直前」にCSSだけで新しい要素（のようなもの）を追加する機能。
1.  `: : before` で追加される要素は、実際の HTML コードの中には書かれておらず、CSSがレンダリング（表示）する際に仮想的に作り出す。
2. 指定された要素のコンテンツ（テキストや子要素など）よりも手前、つまり要素の開始タグのすぐ内側のような位置に挿入される。
3.  `: : before` を使うには、必ずCSSで `content` プロパティを指定する必要があり、ここで追加する要素の中身（テキストや空文字など）を定義するが、`content : ""; `のように空を指定することも多い。
5.  `: : before` で作られた仮想的な要素に対しても、通常のHTML要素と同じように、色、サイズ、背景、ボーダーなどのCSSスタイルを適用できる。
-  `collapse` は隣接するセルで境界線を共有する。
-  `text-align: center;`  は、CSSのプロパティで、ブロックレベル要素（またはテーブルセル）の内部にあるインラインレベルのコンテンツ（主にテキスト）を水平方向（左右）に中央揃えする ための指定。